### PR TITLE
catch compressor exceptions and show them in the cli

### DIFF
--- a/jim.gemspec
+++ b/jim.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Aaron Quint"]
-  s.date = %q{2010-09-26}
+  s.date = %q{2010-11-04}
   s.default_executable = %q{jim}
   s.description = %q{jim is your friendly javascript library manager. He downloads, stores, bundles, vendors and compresses.}
   s.email = %q{aaron@quirkey.com}

--- a/lib/jim.rb
+++ b/lib/jim.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'downlow'
 require 'logger'
 require 'yajl'

--- a/lib/jim.rb
+++ b/lib/jim.rb
@@ -1,3 +1,4 @@
+require 'rubygems'
 require 'downlow'
 require 'logger'
 require 'yajl'

--- a/lib/jim/bundler.rb
+++ b/lib/jim/bundler.rb
@@ -111,7 +111,11 @@ module Jim
         end
         compressor = ::Closure::Compiler.new
       end
-      compressor.compress(uncompressed)
+      begin
+        compressor.compress(uncompressed)
+      rescue Exception => e
+        puts e.message
+      end
     end
 
     private

--- a/lib/jim/cli.rb
+++ b/lib/jim/cli.rb
@@ -166,15 +166,20 @@ module Jim
 
       puts "*** Now watching JS files..."
 
-      FSSM.monitor(Dir.pwd, [File.join('dir','*.js'), 'Jimfile']) do
+      puts File.join('**','*.js')
+      FSSM.monitor(Dir.pwd, [File.join('**','*.js'), 'Jimfile']) do
         update do |base, relative|
-          puts "--> #{relative} changed!"
-          system "jim bundle"
+          unless relative.include?('bundled.js')
+            puts "--> #{relative} changed!"
+            system "jim bundle"
+          end
         end
 
         create do |base, relative|
-          puts "--> #{relative} created!"
-          system "jim bundle"
+          unless relative.include?('bundled.js')
+            puts "--> #{relative} created!"
+            system "jim bundle"
+          end
         end
 
         delete do |base, relative|

--- a/lib/jim/cli.rb
+++ b/lib/jim/cli.rb
@@ -161,6 +161,30 @@ module Jim
       compress
     end
 
+    def watch(dir = nil)
+      require 'fssm'
+
+      puts "*** Now watching JS files..."
+
+      FSSM.monitor(Dir.pwd, [File.join('dir','*.js'), 'Jimfile']) do
+        update do |base, relative|
+          puts "--> #{relative} changed!"
+          system "jim bundle"
+        end
+
+        create do |base, relative|
+          puts "--> #{relative} created!"
+          system "jim bundle"
+        end
+
+        delete do |base, relative|
+          puts "--> #{relative} deleted!"
+          system "jim bundle"
+        end
+      end
+
+    end
+
     private
     def parse_options(runtime_args)
       OptionParser.new("", 24, '  ') do |opts|

--- a/lib/jim/templates/commands
+++ b/lib/jim/templates/commands
@@ -51,6 +51,10 @@ pack [vendor_dir]
   workflow of vendoring and re-bundling before commiting or deploying changes
   to a project
 
+watch
+  Watches your Jimfile and JS files and triggers a `jim bundle` if something
+  changes. Handy for development.
+
 commands
   Print this help file
 

--- a/test/test_jim_cli.rb
+++ b/test/test_jim_cli.rb
@@ -76,6 +76,12 @@ class TestJimCLI < Test::Unit::TestCase
       end
     end
 
+    context "watch" do
+      should_eventually "watch changed js files then run bundle" do
+        #not sure how this should be tested... ideas?
+      end
+    end
+
   end
 
   def run_cli(*args)


### PR DESCRIPTION
If closure or yui compressor error out, jim doesn't display the error.  This patch fixes that.
